### PR TITLE
Set action status to failure when auto-merge fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,11 @@ inputs:
     description: The pull request label.
     default: gitflow
   auto-merge:
-    description: If `true`, will try to automatically merge the pull requests.
+    description: If `true`, will try to automatically merge pull requests. Can also be set to `pull_request_review`, `check_run`, `push`, or a comma-separated combination of these values to only merge when handling the named events.
     default: true
+  require-merge:
+    description: If an attempted merge fails, the action is considered to have failed.
+    default: false
 
 runs:
   using: 'node12'

--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,7 @@ function isAutoMergeEvent(eventName) {
         return true;
     }
     else {
-        const auto_merge_events = auto_merge.split(",");
+        const auto_merge_events = auto_merge.split(",").map(e => e.trim());
         return auto_merge_events.includes(eventName);
     }
 }
@@ -163,11 +163,12 @@ async function merge(pull_number) {
         core.debug(JSON.stringify(mergeResponse.data));
     }
     catch (err) {
-        core.info("Merge failed.");
-        core.debug(err);
         if (require_merge) {
             core.setFailed("Merge failed.");
+        } else {
+            core.info("Merge failed.");
         }
+        core.debug(err);
     }
 }
 


### PR DESCRIPTION
I tried to set up a notification for when auto-merge fails, but discovered that "Merged failed" is logged without setting the action status to failure. This should take care of that.