### PR TITLE
Add PR number to output when triggered by push

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ jobs:
         auto-merge: true # If `true`, will try to automatically merge the pull requests.
 ```
 
+### Output
+When triggered by a push event, the pull request number which is created or found to
+already exist is stored in the `pull-request` output variable.
+
 ### Auto update
 You can use (at your own risk) the `release` branch instead of the specific version tag.  
 Never user `master`, since the distribution file does not exist in this branch and the action will always fail.

--- a/src/main.js
+++ b/src/main.js
@@ -133,6 +133,7 @@ async function push() {
         core.info(`Label ${label} added to #${pull_number}.`);
         core.debug(JSON.stringify(labelsResponse.data));
     }
+    core.setOutput("pull-request", pull_number.toString());
     if (auto_merge) {
         await merge(pull_number);
     }


### PR DESCRIPTION
It might be desirable to output the pull number when handling other triggers, but I wasn't sure what would be useful in the case of `check_run`, when multiple PRs might be merged, so I kept my change narrow.