### PR TITLE
Replacing check_run by check_suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0 - 2020-XX-XX
+- [BREAKING] Replaced `check_run` by `check_suite`.
+
 ## 0.0.4 - 2019-11-13
 - `auto-merge` input now also accepts comma separated events:
   - `pull_request_review`;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ on:
   push:
   # To merge pull requests if not possible during the push run. Remove if `auto-merge` is `false`.
   pull_request_review:
-  check_run:
+  check_suite:
     types: [completed]
     
 jobs:
@@ -23,7 +23,7 @@ jobs:
     name: Gitflow
     runs-on: ubuntu-16.04
     steps:
-    - uses: Logerfo/gitflow-action@0.0.4
+    - uses: Logerfo/gitflow-action@1.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} # The `GITHUB_TOKEN` secret.
 ```
@@ -40,7 +40,7 @@ jobs:
     name: Gitflow
     runs-on: ubuntu-16.04
     steps:
-    - uses: Logerfo/gitflow-action@0.0.4
+    - uses: Logerfo/gitflow-action@1.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} # The `GITHUB_TOKEN` secret.
         auto-merge: false # If `true`, will try to automatically merge the pull requests.
@@ -55,7 +55,7 @@ on:
   push:
   # To merge pull requests if not possible during the push run. Remove if `auto-merge` is `false`.
   pull_request_review:
-  check_run:
+  check_suite:
     types: [completed]
 
 jobs:
@@ -63,14 +63,14 @@ jobs:
     name: Gitflow
     runs-on: ubuntu-16.04
     steps:
-    - uses: Logerfo/gitflow-action@0.0.4
+    - uses: Logerfo/gitflow-action@1.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} # The `GITHUB_TOKEN` secret.
         release: release # The `release` branch.
         dev: dev # The `dev` branch.
         master: master # The `master` branch.
         label: gitflow # The pull request label.
-        auto-merge: true # If `true`, will try to automatically merge pull requests. Can also be set to `pull_request_review`, `check_run`, `push`, or a comma-separated combination of these values to only merge when handling the named events.
+        auto-merge: true # If `true`, will try to automatically merge pull requests. Can also be set to `pull_request_review`, `check_suite`, `push`, or a comma-separated combination of these values to only merge when handling the named events.
         require-merge: false # If an attempted merge fails, the action is considered to have failed.
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: The pull request label.
     default: gitflow
   auto-merge:
-    description: If `true`, will try to automatically merge pull requests. Can also be set to `pull_request_review`, `check_run`, `push`, or a comma-separated combination of these values to only merge when handling the named events.
+    description: If `true`, will try to automatically merge pull requests. Can also be set to `pull_request_review`, `check_suite`, `push`, or a comma-separated combination of these values to only merge when handling the named events.
     default: true
   require-merge:
     description: If an attempted merge fails, the action is considered to have failed.

--- a/src/main.js
+++ b/src/main.js
@@ -62,9 +62,9 @@ async function run() {
                 }
                 break;
 
-            case "check_run":
-                if (isAutoMergeEvent("check_run")) {
-                    var prs = context.payload.check_run.pull_requests;
+            case "check_suite":
+                if (isAutoMergeEvent("check_suite")) {
+                    var prs = context.payload.check_suite.pull_requests;
                     if (!prs) {
                         core.info("Empty pull request list. Stepping out...");
                         return;
@@ -86,7 +86,7 @@ async function run() {
                     }
                 }
                 else {
-                    core.info("Auto merge is disabled for check runs. You should remove the `check_run` event from the action configuration. Skipping...");
+                    core.info("Auto merge is disabled for check runs. You should remove the `check_suite` event from the action configuration. Skipping...");
                 }
                 break;
         }


### PR DESCRIPTION
Fixes #23.
Currently untested.
Maybe we could support both `check_run` and `check_suite` in order to make the change non-breaking? What about supporting both simultaneously?