### PR TITLE
Update release and master branch to support regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     - uses: Logerfo/gitflow-action@0.0.4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} # The `GITHUB_TOKEN` secret.
-        release: release # The `release` branch.
+        release: release # The `release` branch. or regex  '^release\/.+'
         dev: dev # The `dev` branch.
         master: master # The `master` branch.
         label: gitflow # The pull request label.

--- a/src/main.js
+++ b/src/main.js
@@ -23,11 +23,16 @@ function getBranch(name) {
 }
 
 function getTarget(head) {
-    switch (head) {
-        case releaseBranch: return masterBranch;
-        case masterBranch: return devBranch;
-        default: return null;
+
+    if (releaseBranch) {
+      const releaseBranchRegex = new RegExp(releaseBranch)
+      if (head.match(releaseBranchRegex)) return masterBranch
+    } else if (masterBranch) {
+      const masterBranchRegex = new RegExp(masterBranch)
+      if (head.match(masterBranchRegex)) return devBranch
     }
+
+    return null
 }
 
 function isAutoMergeEvent(eventName) {

--- a/src/main.js
+++ b/src/main.js
@@ -24,12 +24,10 @@ function getBranch(name) {
 
 function getTarget(head) {
 
-    if (releaseBranch) {
-      const releaseBranchRegex = new RegExp(releaseBranch)
-      if (head.match(releaseBranchRegex)) return masterBranch
-    } else if (masterBranch) {
-      const masterBranchRegex = new RegExp(masterBranch)
-      if (head.match(masterBranchRegex)) return devBranch
+    if (releaseBranch && head.match(new RegExp(releaseBranch))) {
+      return masterBranch
+    } else if (masterBranch && head.match(new RegExp(masterBranch))) {
+      return devBranch
     }
 
     return null


### PR DESCRIPTION
Update release and master branch attribute to be based on a regex. This is due to my requirement that I wanted this to work for `RELEASE/xxx` branches. This will still work with default branches if no regex is used since the condition below.

```
if ("release".match(new RegExp("release"))) return "I WILL BE TRUE"
```

Thanks for the action it is really awesome

-----
[View rendered README.md](https://github.com/pocket-engineering/gitflow-action/blob/master/README.md)